### PR TITLE
Added String Format to span in IvanLoader.razor component to accommodate IvanLoaderTypes 1-9.

### DIFF
--- a/One1Lion.BlazorComponents/One1Lion.Loader/IvanLoader.razor
+++ b/One1Lion.BlazorComponents/One1Lion.Loader/IvanLoader.razor
@@ -1,6 +1,6 @@
 ﻿@if (Show) {
   <span style="@(styles)">
-    <span class="loader-@((int)Type) @AddCssClass" title="@Tooltip" @attributes="AdditionalAttributes"></span>
+    <span class="loader-@($"{(int)Type:00}") @AddCssClass" title="@Tooltip" @attributes="AdditionalAttributes"></span>
   </span>
 }
 


### PR DESCRIPTION
Added String Format to span in IvanLoader.razor component to accommodate IvanLoaderTypes 1-9.
@($"{(int)Type:00}")